### PR TITLE
Fix: Make CloudEvent subject field optional

### DIFF
--- a/src/api/models.py
+++ b/src/api/models.py
@@ -29,7 +29,8 @@ class CloudEvent(BaseModel):
     datacontenttype: str = "application/json"
     type: str
     source: str
-    subject: str
+    #subject: str
+    subject: typing.Optional[str] = None
     data: typing.Dict[str, typing.Any]
 
 


### PR DESCRIPTION
## Problem
- Events without the mandatory `subject` field were causing 500 Internal Server Error

## Solution
- Changed `subject` field from required to `Optional[str]` with `None` default

## Impact
- Prevents application crashes when receiving events without subject field
- Improves robustness and error handling
- No breaking changes for events that include subject

## Testing
- Tested with incoming events lacking the subject field and with subject field
- Application now handles missing subject gracefully without returning 500 errors